### PR TITLE
[REFACTOR] 원자적 업데이트로 수정 및 트랜잭션 격리수준 설정

### DIFF
--- a/src/main/java/org/bbagisix/asset/mapper/AssetMapper.java
+++ b/src/main/java/org/bbagisix/asset/mapper/AssetMapper.java
@@ -36,5 +36,5 @@ public interface AssetMapper {
 	);
 
 	// 저금통 계좌 잔액 업데이트(아낀금액만큼 증가)
-	int updateSavingAssetBalance(@Param("assetId") Long assetId, @Param("totalSaving") Long totalSaving);
+	int updateSavingAssetBalance(@Param("userId") Long userId, @Param("totalSaving") Long totalSaving);
 }

--- a/src/main/java/org/bbagisix/saving/service/SavingService.java
+++ b/src/main/java/org/bbagisix/saving/service/SavingService.java
@@ -11,6 +11,7 @@ import org.bbagisix.common.exception.ErrorCode;
 import org.bbagisix.saving.dto.SavingDTO;
 import org.bbagisix.saving.mapper.SavingMapper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -43,7 +44,7 @@ public class SavingService {
 		}
 	}
 
-	@Transactional(rollbackFor = Exception.class)
+	@Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_COMMITTED)
 	public void updateSaving(Long userId, Long userChallengeId) {
 
 		try {// 해당 userChallenge 조회
@@ -55,14 +56,8 @@ public class SavingService {
 				throw new BusinessException(ErrorCode.SAVING_UPDATE_DENIED);
 			Long totalSaving = userChallenge.getSaving() * userChallenge.getPeriod();
 
-			// user 계좌(sub) 조회
-			AssetVO asset;
-			asset = assetMapper.selectAssetByUserIdAndStatus(userId, "sub");
-			if (asset == null)
-				throw new BusinessException(ErrorCode.ASSET_NOT_FOUND);
-
 			// balance update
-			int updated = assetMapper.updateSavingAssetBalance(asset.getAssetId(), totalSaving);
+			int updated = assetMapper.updateSavingAssetBalance(userId, totalSaving);
 			if (updated != 1) {
 				throw new BusinessException(ErrorCode.SAVING_UPDATE_FAILED);
 			}

--- a/src/main/resources/mappers/asset/AssetMapper.xml
+++ b/src/main/resources/mappers/asset/AssetMapper.xml
@@ -143,7 +143,7 @@
     <update id="updateSavingAssetBalance">
         UPDATE user_asset
         SET balance=balance + #{totalSaving}
-        WHERE asset_id = #{assetId}
+        WHERE user_id = #{userId} and status='sub'
     </update>
 
 </mapper>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#3 

## ✨ 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- assetid를 가져오는 select문을 삭제하고, update문에서 userId와 status로 계좌를 찾아 한번에 업데이트 하도록 하였다.
  - 한 유저당 저금통 계좌는 1개만 등록할 수 있으므로, 굳이 assetId를 가져올 필요가 없기 때문.
  - 원자적 연산으로 변환되어 동시성 제어가 가능해짐.
- 동시성/대기 측면을 고려하여 격리수준을 READ COMMITTED로 설정하였다.

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스
<!-- 참고할 사항이 있다면 적어주세요 -->
